### PR TITLE
Update otel_values.yaml

### DIFF
--- a/otel-astro-demo/otel_values.yaml
+++ b/otel-astro-demo/otel_values.yaml
@@ -847,7 +847,10 @@ opentelemetry-collector:
       #         - container_memory_.*
       #         - kube_.*
       #         - system.*
-      memory_limiter: null
+      memory_limiter:
+        limit_percentage: 80
+        spike_limit_percentage: 25
+        check_interval: 5s        
       
     connectors:
       spanmetrics: {}


### PR DESCRIPTION
hardcode memory limiter values to fix issue when using self hosted ec2 machines that don't render the yaml correctly
